### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/AssistantBOT.py
+++ b/AssistantBOT.py
@@ -36,8 +36,7 @@ import prawcore
 import psutil
 import requests
 import yaml
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import process
 from pbwrap import Pastebin
 from requests.exceptions import ConnectionError
 
@@ -4296,8 +4295,7 @@ def messaging_parse_flair_response(subreddit_name, response_text, post_id):
         # Returns as tuple `('FLAIR' (text), INT)`
         # If the match is higher than or equal to `min_fuzz_ratio`, then
         # assign that to `returned_template`. Otherwise, `None`.
-        best_match = process.extractOne(response_text, list(lowercased_flair_dict.keys()),
-                                        scorer=fuzz.WRatio)
+        best_match = process.extractOne(response_text, list(lowercased_flair_dict.keys()))
         if best_match[1] >= SETTINGS.min_fuzz_ratio:  # We are very sure this is right.
             returned_template = lowercased_flair_dict[best_match[0]]['id']
             flair_match_text = best_match[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-fuzzywuzzy
+rapidfuzz
 pbwrap
 praw>=6.1.0
 prawcore
 psutil
-python-Levenshtein
 pyyaml>=5.1.0
 requests


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.